### PR TITLE
improve UID logic to avoid UID clash between semesters

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,8 +257,26 @@
       var date_time = new Date(date + 'T' + time);
       return date_time;
     }
+    
+    // Add semester determination logic
+    function determineSemester(dateStr) {
+      const date = new Date(dateStr);
+      const year = date.getFullYear();
+      const month = date.getMonth() + 1; // JavaScript months are 0-based
 
-    var cal = ics();
+      // First semester: July to December
+      // Second semester: January to June
+      if (month >= 7) {
+        return `${year}S1`;
+      } else {
+        return `${year-1}S2`; // Use previous year for Spring semester
+      }
+    }
+
+    // Get semester identifier based on start date
+    const semesterId = determineSemester(startDate);
+    var cal = ics(`${semesterId}.uic`)
+
     for (var i = 0; i < course_ds_date.length; i++){
       for (var j = 0; j < course_ds_date[i][1].length; j++) {
         cal.addEvent(course_ds_date[i][0][0], '', course_ds_date[i][0][1], mergeDateTime(course_ds_date[i][1][j], course_ds_date[i][2][0]), mergeDateTime(course_ds_date[i][1][j], course_ds_date[i][2][1]), {


### PR DESCRIPTION
This pull request introduces a change to the `index.html` file to add logic for determining the semester based on a given start date. The most important change is the addition of a new function to calculate the semester identifier.

Improvements to semester determination:

* Added the `determineSemester` function to calculate the semester identifier based on the start date. The function checks the month to determine whether it falls in the first semester (July to December) or the second semester (January to June) and adjusts the year accordingly. The semester identifier is then used to create the `.ics` file with the appropriate and unique UID.